### PR TITLE
Add Dockerized tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM openfl/openfl:develop
+
+## install node/npm
+ADD https://deb.nodesource.com/setup_8.x /opt/node8setup.sh
+RUN chmod +x /opt/node8setup.sh && /opt/node8setup.sh
+RUN apt-get install -y --no-install-recommends nodejs
+
+## tests need these modules, let's have them in global namespace
+RUN npm install http-server -g
+RUN npm install webpack -g
+
+## install hxgenjs
+## re-install if repo changed and clear docker cache
+ADD https://api.github.com/repos/jgranick/hxgenjs/compare/master...HEAD /dev/null
+RUN haxelib git hxgenjs https://github.com/jgranick/hxgenjs
+
+## pull repository
+## re-install if repo changed and clear docker cache
+RUN git clone https://github.com/openfl/openfl-js /opt/openfl-js
+ADD https://api.github.com/repos/openfl/openfl-js/compare/master...HEAD /dev/null
+
+WORKDIR /opt/openfl-js
+RUN git pull
+RUN npm install
+RUN npm run build -s
+RUN npm link
+
+# more logs from npm
+ENV NPM_CONFIG_LOGLEVEL info

--- a/package.json
+++ b/package.json
@@ -51,5 +51,11 @@
 
 		"test-es5-all":					"npm run test-es5-helloworld && npm run test-es5-displayingabitmap && npm run test-es5-bunnymark",
 
+		"test-es6-helloworld":			"cross-env TESTNAME=es6_helloworld TESTDIR=samples/es6/helloworld npm run docker-test-build",
+		"test-es6-displayingabitmap":	"cross-env TESTNAME=es6_displayingabitmap TESTDIR=samples/es6/DisplayingABitmap npm run docker-test-build",
+		"test-es6-bunnymark":			"cross-env TESTNAME=es6_bunnymark TESTDIR=samples/es6/BunnyMark npm run docker-test-build",
+
+		"test-es6-all":					"npm run test-es6-helloworld && npm run test-es6-displayingabitmap && npm run test-es6-bunnymark",
+
 	}
 }

--- a/package.json
+++ b/package.json
@@ -35,5 +35,6 @@
 		"docker-build-clean":			"docker build --no-cache -t openfl/openfl_js .",
 
 		"docker-test-clean":			"docker ps -a -q --filter \"name=openfljs_test_$TESTNAME\" | xargs docker stop | xargs docker rm -fv",
+		"docker-tests-clean":			"docker ps -a -q --filter \"name=openfljs_test_*\" | xargs docker stop | xargs docker rm -fv",
 	}
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,12 @@
 		"url": "https://github.com/openfl/openfl-js.git"
 	},
 	"scripts": {
-		"build": "cd scripts/build && haxe build.hxml",
-		"prepublishOnly": "npm run build"
+		"build":						"cd scripts/build && haxe build.hxml",
+		"prepublishOnly":				"npm run build",
+
+		"docker-build":					"if [[ \"$(docker images -q openfl/openfl_js)\" == \"\" ]]; then docker build -t openfl/openfl_js .; fi",
+		"docker-rebuild":				"docker build -t openfl/openfl_js .",
+		"docker-build-clean":			"docker build --no-cache -t openfl/openfl_js .",
+
 	}
 }

--- a/package.json
+++ b/package.json
@@ -63,5 +63,7 @@
 
 		"test-haxe-all":				"npm run test-haxe-helloworld && npm run test-haxe-displayingabitmap && npm run test-haxe-bunnymark",
 
+		"test-all":						"npm run test-es5-all && npm run test-es6-all && npm run test-haxe-all"
+
 	}
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
 		"type": "git",
 		"url": "https://github.com/openfl/openfl-js.git"
 	},
+	"devDependencies": {
+		"cross-env": "*"
+	},
 	"scripts": {
 		"build":						"cd scripts/build && haxe build.hxml",
 		"prepublishOnly":				"npm run build",
@@ -41,6 +44,12 @@
 		"docker-test-clean":			"docker ps -a -q --filter \"name=openfljs_test_$TESTNAME\" | xargs docker stop | xargs docker rm -fv",
 		"docker-tests-clean":			"docker ps -a -q --filter \"name=openfljs_test_*\" | xargs docker stop | xargs docker rm -fv",
 		"docker-tests-list":			"docker ps --format='{{.Names}} {{.Ports}}' --filter 'name=openfljs_test_*' | awk -F'[->]' '{print $1}' | awk -F'[ ]' '{print \"http://\" $2 \" runs \"$1 }' && echo && echo after you\\'re finished run : npm run docker-tests-clean",
+
+		"test-es5-helloworld":			"cross-env TESTNAME=es5_helloworld TESTDIR=samples/es5/helloworld npm run docker-test-build",
+		"test-es5-displayingabitmap":	"cross-env TESTNAME=es5_displayingabitmap TESTDIR=samples/es5/DisplayingABitmap npm run docker-test-build",
+		"test-es5-bunnymark":			"cross-env TESTNAME=es5_bunnymark TESTDIR=samples/es5/BunnyMark npm run docker-test-build",
+
+		"test-es5-all":					"npm run test-es5-helloworld && npm run test-es5-displayingabitmap && npm run test-es5-bunnymark",
 
 	}
 }

--- a/package.json
+++ b/package.json
@@ -34,5 +34,6 @@
 		"docker-rebuild":				"docker build -t openfl/openfl_js .",
 		"docker-build-clean":			"docker build --no-cache -t openfl/openfl_js .",
 
+		"docker-test-clean":			"docker ps -a -q --filter \"name=openfljs_test_$TESTNAME\" | xargs docker stop | xargs docker rm -fv",
 	}
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
 		"docker-rebuild":				"docker build -t openfl/openfl_js .",
 		"docker-build-clean":			"docker build --no-cache -t openfl/openfl_js .",
 
+		"docker-test-run":				"docker run -d --name openfljs_test_$TESTNAME -p 8080 openfl/openfl_js_test_$TESTNAME && npm run docker-tests-list",
+
 		"docker-test-clean":			"docker ps -a -q --filter \"name=openfljs_test_$TESTNAME\" | xargs docker stop | xargs docker rm -fv",
 		"docker-tests-clean":			"docker ps -a -q --filter \"name=openfljs_test_*\" | xargs docker stop | xargs docker rm -fv",
 		"docker-tests-list":			"docker ps --format='{{.Names}} {{.Ports}}' --filter 'name=openfljs_test_*' | awk -F'[->]' '{print $1}' | awk -F'[ ]' '{print \"http://\" $2 \" runs \"$1 }' && echo && echo after you\\'re finished run : npm run docker-tests-clean",

--- a/package.json
+++ b/package.json
@@ -57,5 +57,11 @@
 
 		"test-es6-all":					"npm run test-es6-helloworld && npm run test-es6-displayingabitmap && npm run test-es6-bunnymark",
 
+		"test-haxe-helloworld":			"cross-env TESTNAME=haxe_helloworld TESTDIR=samples/haxe/helloworld npm run docker-test-build",
+		"test-haxe-displayingabitmap":	"cross-env TESTNAME=haxe_displayingabitmap TESTDIR=samples/haxe/DisplayingABitmap npm run docker-test-build",
+		"test-haxe-bunnymark":			"cross-env TESTNAME=haxe_bunnymark TESTDIR=samples/haxe/BunnyMark npm run docker-test-build",
+
+		"test-haxe-all":				"npm run test-haxe-helloworld && npm run test-haxe-displayingabitmap && npm run test-haxe-bunnymark",
+
 	}
 }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,13 @@
 
 		"test-haxe-all":				"npm run test-haxe-helloworld && npm run test-haxe-displayingabitmap && npm run test-haxe-bunnymark",
 
-		"test-all":						"npm run test-es5-all && npm run test-es6-all && npm run test-haxe-all"
+		"test-ts-helloworld":			"cross-env TESTNAME=ts_helloworld TESTDIR=samples/typescript/helloworld npm run docker-test-build",
+		"test-ts-displayingabitmap":	"cross-env TESTNAME=ts_displayingabitmap TESTDIR=samples/typescript/DisplayingABitmap npm run docker-test-build",
+		"test-ts-bunnymark":			"cross-env TESTNAME=ts_bunnymark TESTDIR=samples/typescript/BunnyMark npm run docker-test-build",
+
+		"test-ts-all":					"npm run test-ts-helloworld && npm run test-ts-displayingabitmap && npm run test-ts-bunnymark",
+
+		"test-all":						"npm run test-es5-all && npm run test-es6-all && npm run test-haxe-all && npm run test-ts-all"
 
 	}
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
 		"docker-rebuild":				"docker build -t openfl/openfl_js .",
 		"docker-build-clean":			"docker build --no-cache -t openfl/openfl_js .",
 
+		"docker-test-build":			"npm run docker-test-clean && docker build -t openfl/openfl_js_test_$TESTNAME $TESTDIR && npm run docker-test-run",
+
 		"docker-test-run":				"docker run -d --name openfljs_test_$TESTNAME -p 8080 openfl/openfl_js_test_$TESTNAME && npm run docker-tests-list",
 
 		"docker-test-clean":			"docker ps -a -q --filter \"name=openfljs_test_$TESTNAME\" | xargs docker stop | xargs docker rm -fv",

--- a/package.json
+++ b/package.json
@@ -36,5 +36,7 @@
 
 		"docker-test-clean":			"docker ps -a -q --filter \"name=openfljs_test_$TESTNAME\" | xargs docker stop | xargs docker rm -fv",
 		"docker-tests-clean":			"docker ps -a -q --filter \"name=openfljs_test_*\" | xargs docker stop | xargs docker rm -fv",
+		"docker-tests-list":			"docker ps --format='{{.Names}} {{.Ports}}' --filter 'name=openfljs_test_*' | awk -F'[->]' '{print $1}' | awk -F'[ ]' '{print \"http://\" $2 \" runs \"$1 }' && echo && echo after you\\'re finished run : npm run docker-tests-clean",
+
 	}
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
 
 		"docker-test-build":			"npm run docker-test-clean && docker build -t openfl/openfl_js_test_$TESTNAME $TESTDIR && npm run docker-test-run",
 
-		"docker-test-run":				"docker run -d --name openfljs_test_$TESTNAME -p 8080 openfl/openfl_js_test_$TESTNAME && npm run docker-tests-list",
+		"docker-test-run":				"docker run -d --name openfljs_test_$TESTNAME -p 8080 openfl/openfl_js_test_$TESTNAME && npm run docker-test-running",
+		"docker-test-running":			"sleep 3 && if [[ `docker inspect -f {{.State.Running}} openfljs_test_$TESTNAME` == \"false\" ]]; then docker logs openfljs_test_$TESTNAME ; else npm run docker-tests-list ; fi",
 
 		"docker-test-clean":			"docker ps -a -q --filter \"name=openfljs_test_$TESTNAME\" | xargs docker stop | xargs docker rm -fv",
 		"docker-tests-clean":			"docker ps -a -q --filter \"name=openfljs_test_*\" | xargs docker stop | xargs docker rm -fv",

--- a/package.json
+++ b/package.json
@@ -30,47 +30,47 @@
 		"cross-env": "*"
 	},
 	"scripts": {
-		"build":						"cd scripts/build && haxe build.hxml",
-		"prepublishOnly":				"npm run build",
+		"build":                        "cd scripts/build && haxe build.hxml",
+		"prepublishOnly":               "npm run build",
 
-		"docker-build":					"if [[ \"$(docker images -q openfl/openfl_js)\" == \"\" ]]; then docker build -t openfl/openfl_js .; fi",
-		"docker-rebuild":				"docker build -t openfl/openfl_js .",
-		"docker-build-clean":			"docker build --no-cache -t openfl/openfl_js .",
+		"docker-build":                 "if [[ \"$(docker images -q openfl/openfl_js)\" == \"\" ]]; then docker build -t openfl/openfl_js .; fi",
+		"docker-rebuild":               "docker build -t openfl/openfl_js .",
+		"docker-build-clean":           "docker build --no-cache -t openfl/openfl_js .",
 
-		"docker-test-build":			"npm run docker-test-clean && docker build -t openfl/openfl_js_test_$TESTNAME $TESTDIR && npm run docker-test-run",
+		"docker-test-build":            "npm run docker-test-clean && docker build -t openfl/openfl_js_test_$TESTNAME $TESTDIR && npm run docker-test-run",
 
-		"docker-test-run":				"docker run -d --name openfljs_test_$TESTNAME -p 8080 openfl/openfl_js_test_$TESTNAME && npm run docker-test-running",
-		"docker-test-running":			"sleep 3 && if [[ `docker inspect -f {{.State.Running}} openfljs_test_$TESTNAME` == \"false\" ]]; then docker logs openfljs_test_$TESTNAME ; else npm run docker-tests-list ; fi",
+		"docker-test-run":              "docker run -d --name openfljs_test_$TESTNAME -p 8080 openfl/openfl_js_test_$TESTNAME && npm run docker-test-running",
+		"docker-test-running":          "sleep 3 && if [[ `docker inspect -f {{.State.Running}} openfljs_test_$TESTNAME` == \"false\" ]]; then docker logs openfljs_test_$TESTNAME ; else npm run docker-tests-list ; fi",
 
-		"docker-test-clean":			"docker ps -a -q --filter \"name=openfljs_test_$TESTNAME\" | xargs docker stop | xargs docker rm -fv",
-		"docker-tests-clean":			"docker ps -a -q --filter \"name=openfljs_test_*\" | xargs docker stop | xargs docker rm -fv",
-		"docker-tests-list":			"docker ps --format='{{.Names}} {{.Ports}}' --filter 'name=openfljs_test_*' | awk -F'[->]' '{print $1}' | awk -F'[ ]' '{print \"http://\" $2 \" runs \"$1 }' && echo && echo after you\\'re finished run : npm run docker-tests-clean",
+		"docker-test-clean":            "docker ps -a -q --filter \"name=openfljs_test_$TESTNAME\" | xargs docker stop | xargs docker rm -fv",
+		"docker-tests-clean":           "docker ps -a -q --filter \"name=openfljs_test_*\" | xargs docker stop | xargs docker rm -fv",
+		"docker-tests-list":            "docker ps --format='{{.Names}} {{.Ports}}' --filter 'name=openfljs_test_*' | awk -F'[->]' '{print $1}' | awk -F'[ ]' '{print \"http://\" $2 \" runs \"$1 }' && echo && echo after you\\'re finished run : npm run docker-tests-clean",
 
-		"test-es5-helloworld":			"cross-env TESTNAME=es5_helloworld TESTDIR=samples/es5/helloworld npm run docker-test-build",
-		"test-es5-displayingabitmap":	"cross-env TESTNAME=es5_displayingabitmap TESTDIR=samples/es5/DisplayingABitmap npm run docker-test-build",
-		"test-es5-bunnymark":			"cross-env TESTNAME=es5_bunnymark TESTDIR=samples/es5/BunnyMark npm run docker-test-build",
+		"test-es5-helloworld":          "cross-env TESTNAME=es5_helloworld TESTDIR=samples/es5/helloworld npm run docker-test-build",
+		"test-es5-displayingabitmap":   "cross-env TESTNAME=es5_displayingabitmap TESTDIR=samples/es5/DisplayingABitmap npm run docker-test-build",
+		"test-es5-bunnymark":           "cross-env TESTNAME=es5_bunnymark TESTDIR=samples/es5/BunnyMark npm run docker-test-build",
 
-		"test-es5-all":					"npm run test-es5-helloworld && npm run test-es5-displayingabitmap && npm run test-es5-bunnymark",
+		"test-es5-all":                 "npm run test-es5-helloworld && npm run test-es5-displayingabitmap && npm run test-es5-bunnymark",
 
-		"test-es6-helloworld":			"cross-env TESTNAME=es6_helloworld TESTDIR=samples/es6/helloworld npm run docker-test-build",
-		"test-es6-displayingabitmap":	"cross-env TESTNAME=es6_displayingabitmap TESTDIR=samples/es6/DisplayingABitmap npm run docker-test-build",
-		"test-es6-bunnymark":			"cross-env TESTNAME=es6_bunnymark TESTDIR=samples/es6/BunnyMark npm run docker-test-build",
+		"test-es6-helloworld":          "cross-env TESTNAME=es6_helloworld TESTDIR=samples/es6/helloworld npm run docker-test-build",
+		"test-es6-displayingabitmap":   "cross-env TESTNAME=es6_displayingabitmap TESTDIR=samples/es6/DisplayingABitmap npm run docker-test-build",
+		"test-es6-bunnymark":           "cross-env TESTNAME=es6_bunnymark TESTDIR=samples/es6/BunnyMark npm run docker-test-build",
 
-		"test-es6-all":					"npm run test-es6-helloworld && npm run test-es6-displayingabitmap && npm run test-es6-bunnymark",
+		"test-es6-all":                 "npm run test-es6-helloworld && npm run test-es6-displayingabitmap && npm run test-es6-bunnymark",
 
-		"test-haxe-helloworld":			"cross-env TESTNAME=haxe_helloworld TESTDIR=samples/haxe/helloworld npm run docker-test-build",
-		"test-haxe-displayingabitmap":	"cross-env TESTNAME=haxe_displayingabitmap TESTDIR=samples/haxe/DisplayingABitmap npm run docker-test-build",
-		"test-haxe-bunnymark":			"cross-env TESTNAME=haxe_bunnymark TESTDIR=samples/haxe/BunnyMark npm run docker-test-build",
+		"test-haxe-helloworld":         "cross-env TESTNAME=haxe_helloworld TESTDIR=samples/haxe/helloworld npm run docker-test-build",
+		"test-haxe-displayingabitmap":  "cross-env TESTNAME=haxe_displayingabitmap TESTDIR=samples/haxe/DisplayingABitmap npm run docker-test-build",
+		"test-haxe-bunnymark":          "cross-env TESTNAME=haxe_bunnymark TESTDIR=samples/haxe/BunnyMark npm run docker-test-build",
 
-		"test-haxe-all":				"npm run test-haxe-helloworld && npm run test-haxe-displayingabitmap && npm run test-haxe-bunnymark",
+		"test-haxe-all":                "npm run test-haxe-helloworld && npm run test-haxe-displayingabitmap && npm run test-haxe-bunnymark",
 
-		"test-ts-helloworld":			"cross-env TESTNAME=ts_helloworld TESTDIR=samples/typescript/helloworld npm run docker-test-build",
-		"test-ts-displayingabitmap":	"cross-env TESTNAME=ts_displayingabitmap TESTDIR=samples/typescript/DisplayingABitmap npm run docker-test-build",
-		"test-ts-bunnymark":			"cross-env TESTNAME=ts_bunnymark TESTDIR=samples/typescript/BunnyMark npm run docker-test-build",
+		"test-ts-helloworld":           "cross-env TESTNAME=ts_helloworld TESTDIR=samples/typescript/helloworld npm run docker-test-build",
+		"test-ts-displayingabitmap":    "cross-env TESTNAME=ts_displayingabitmap TESTDIR=samples/typescript/DisplayingABitmap npm run docker-test-build",
+		"test-ts-bunnymark":            "cross-env TESTNAME=ts_bunnymark TESTDIR=samples/typescript/BunnyMark npm run docker-test-build",
 
-		"test-ts-all":					"npm run test-ts-helloworld && npm run test-ts-displayingabitmap && npm run test-ts-bunnymark",
+		"test-ts-all":                  "npm run test-ts-helloworld && npm run test-ts-displayingabitmap && npm run test-ts-bunnymark",
 
-		"test-all":						"npm run test-es5-all && npm run test-es6-all && npm run test-haxe-all && npm run test-ts-all"
+		"test-all":                     "npm run test-es5-all && npm run test-es6-all && npm run test-haxe-all && npm run test-ts-all"
 
 	}
 }

--- a/samples/es5/BunnyMark/Dockerfile
+++ b/samples/es5/BunnyMark/Dockerfile
@@ -1,0 +1,13 @@
+FROM openfl/openfl_js
+
+# this is where we test, change if you want to test something else
+WORKDIR /opt/openfl-js/samples/es5/BunnyMark
+RUN npm link openfl
+RUN npm install -s
+
+# if you're testing locally, you might want to overwrite with your local files
+# ADD entry.js /opt/openfl-js/samples/es5/BunnyMark/entry.js
+# ADD Main.js /opt/openfl-js/samples/es5/BunnyMark/Main.js
+
+EXPOSE 8080
+CMD npm run test -s

--- a/samples/es5/DisplayingABitmap/Dockerfile
+++ b/samples/es5/DisplayingABitmap/Dockerfile
@@ -1,0 +1,12 @@
+FROM openfl/openfl_js
+
+# this is where we test, change if you want to test something else
+WORKDIR /opt/openfl-js/samples/es5/DisplayingABitmap
+RUN npm link openfl
+RUN npm install -s
+
+# if you're testing locally, you might want to overwrite with your local files
+# ADD entry.js /opt/openfl-js/samples/es5/DisplayingABitmap/entry.js
+
+EXPOSE 8080
+CMD npm run test -s

--- a/samples/es5/helloworld/Dockerfile
+++ b/samples/es5/helloworld/Dockerfile
@@ -1,0 +1,12 @@
+FROM openfl/openfl_js
+
+# this is where we test, change if you want to test something else
+WORKDIR /opt/openfl-js/samples/es5/helloworld
+RUN npm link openfl
+RUN npm install -s
+
+# if you're testing locally, you might want to overwrite with your local files
+# ADD entry.js /opt/openfl-js/samples/es5/helloworld/entry.js
+
+EXPOSE 8080
+CMD npm run test -s

--- a/samples/es6/BunnyMark/Dockerfile
+++ b/samples/es6/BunnyMark/Dockerfile
@@ -1,0 +1,13 @@
+FROM openfl/openfl_js
+
+# this is where we test, change if you want to test something else
+WORKDIR /opt/openfl-js/samples/es6/BunnyMark
+RUN npm link openfl
+RUN npm install -s
+
+# if you're testing locally, you might want to overwrite with your local files
+# ADD entry.js /opt/openfl-js/samples/es6/BunnyMark/entry.js
+# ADD Main.js /opt/openfl-js/samples/es6/BunnyMark/Main.js
+
+EXPOSE 8080
+CMD npm run test -s

--- a/samples/es6/DisplayingABitmap/Dockerfile
+++ b/samples/es6/DisplayingABitmap/Dockerfile
@@ -1,0 +1,12 @@
+FROM openfl/openfl_js
+
+# this is where we test, change if you want to test something else
+WORKDIR /opt/openfl-js/samples/es6/DisplayingABitmap
+RUN npm link openfl
+RUN npm install -s
+
+# if you're testing locally, you might want to overwrite with your local files
+# ADD entry.js /opt/openfl-js/samples/es6/DisplayingABitmap/entry.js
+
+EXPOSE 8080
+CMD npm run test -s

--- a/samples/es6/helloworld/Dockerfile
+++ b/samples/es6/helloworld/Dockerfile
@@ -1,0 +1,12 @@
+FROM openfl/openfl_js
+
+# this is where we test, change if you want to test something else
+WORKDIR /opt/openfl-js/samples/es6/helloworld
+RUN npm link openfl
+RUN npm install -s
+
+# if you're testing locally, you might want to overwrite with your local files
+# ADD entry.js /opt/openfl-js/samples/es6/helloworld/entry.js
+
+EXPOSE 8080
+CMD npm run test -s

--- a/samples/haxe/BunnyMark/Dockerfile
+++ b/samples/haxe/BunnyMark/Dockerfile
@@ -1,0 +1,17 @@
+FROM openfl/openfl_js
+
+# this is where we test, change if you want to test something else
+WORKDIR /opt/openfl-js/samples/haxe/BunnyMark
+RUN npm link openfl
+RUN npm install -s
+
+# if you're testing locally, you might want to overwrite with your local files
+# ADD Main.hx /opt/openfl-js/samples/haxe/BunnyMark/Main.hx
+# ADD Bunny.hx /opt/openfl-js/samples/haxe/BunnyMark/Bunny.hx
+
+# fix for hxgenjs
+RUN rm -f /opt/openfl-js/lib/haxe/io/Error.hx
+
+EXPOSE 8080
+RUN npm run build
+CMD npm run test -s

--- a/samples/haxe/DisplayingABitmap/Dockerfile
+++ b/samples/haxe/DisplayingABitmap/Dockerfile
@@ -1,0 +1,16 @@
+FROM openfl/openfl_js
+
+# this is where we test, change if you want to test something else
+WORKDIR /opt/openfl-js/samples/haxe/DisplayingABitmap
+RUN npm link openfl
+RUN npm install -s
+
+# if you're testing locally, you might want to overwrite with your local files
+# ADD Main.hx /opt/openfl-js/samples/haxe/DisplayingABitmap/Main.hx
+
+# fix for hxgenjs
+RUN rm -f /opt/openfl-js/lib/haxe/io/Error.hx
+
+EXPOSE 8080
+RUN npm run build
+CMD npm run test -s

--- a/samples/haxe/helloworld/Dockerfile
+++ b/samples/haxe/helloworld/Dockerfile
@@ -1,0 +1,16 @@
+FROM openfl/openfl_js
+
+# this is where we test, change if you want to test something else
+WORKDIR /opt/openfl-js/samples/haxe/helloworld
+RUN npm link openfl
+RUN npm install -s
+
+# if you're testing locally, you might want to overwrite with your local files
+# ADD Main.hx /opt/openfl-js/samples/haxe/helloworld/Main.hx
+
+# fix for hxgenjs
+RUN rm -f /opt/openfl-js/lib/haxe/io/Error.hx
+
+EXPOSE 8080
+RUN npm run build
+CMD npm run test -s

--- a/samples/typescript/BunnyMark/Dockerfile
+++ b/samples/typescript/BunnyMark/Dockerfile
@@ -1,0 +1,14 @@
+FROM openfl/openfl_js
+
+# this is where we test, change if you want to test something else
+WORKDIR /opt/openfl-js/samples/typescript/BunnyMark
+RUN npm link openfl
+RUN npm install typescript -g
+RUN npm install -s
+
+# if you're testing locally, you might want to overwrite with your local files
+# ADD entry.ts /opt/openfl-js/samples/typescript/BunnyMark/entry.ts
+# ADD Main.ts /opt/openfl-js/samples/typescript/BunnyMark/Main.ts
+
+EXPOSE 8080
+CMD npm run test -s

--- a/samples/typescript/DisplayingABitmap/Dockerfile
+++ b/samples/typescript/DisplayingABitmap/Dockerfile
@@ -1,0 +1,14 @@
+FROM openfl/openfl_js
+
+# this is where we test, change if you want to test something else
+WORKDIR /opt/openfl-js/samples/typescript/DiplayingABitmap
+RUN npm link openfl
+RUN npm install typescript -g
+RUN npm install -s
+
+# if you're testing locally, you might want to overwrite with your local files
+# ADD entry.ts /opt/openfl-js/samples/typescript/DiplayingABitmap/entry.ts
+# ADD Main.ts /opt/openfl-js/samples/typescript/DiplayingABitmap/Main.ts
+
+EXPOSE 8080
+CMD npm run test -s

--- a/samples/typescript/helloworld/Dockerfile
+++ b/samples/typescript/helloworld/Dockerfile
@@ -1,0 +1,13 @@
+FROM openfl/openfl_js
+
+# this is where we test, change if you want to test something else
+WORKDIR /opt/openfl-js/samples/typescript/helloworld
+RUN npm link openfl
+RUN npm install typescript -g
+RUN npm install -s
+
+# if you're testing locally, you might want to overwrite with your local files
+# ADD entry.ts /opt/openfl-js/samples/typescript/helloworld/entry.ts
+
+EXPOSE 8080
+CMD npm run test -s


### PR DESCRIPTION
Removes issues with local configs since it runs the tests inside their own pre-configured Docker containers. Depends on official `openfl/lime:develop` and `openfl/openfl:develop` builds. Also good entry point to see how to run the samples.

Run with : 

```
npm run test-all // runs all tests

npm run test-es5-all // runs all es5 tests
npm run test-es6-all // runs all es6 tests
npm run test-haxe-all // runs all haxe tests
npm run test-ts-all // runs all typescript tests
```
To run specific tests replace * with es5, es6, haxe or ts :
```
npm run test-*-helloworld
npm run test-*-displayingabitmap
npm run test-*-bunnymark
```

After the test was built and is running, navigate to http://localhost:[port-number]. The full address will be displayed on successful test build.

To clean up the running docker containers run `npm run docker-tests-clean`

#### TODO
- Instead of running tests on server-basis, check the return value and then fail/pass based on if page was loadable without errors.
- double-check `npm run docker-tests-list` works on windows